### PR TITLE
Remove laravel as a direct dependency of this package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     "require": {
         "php": "^8.1",
         "creode/laravel-account-approval": "^1.1",
-        "illuminate/contracts": "^10.0 | ^11.0 | ^12.0",
         "laravel/nova": "^4.32 | ^5.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },


### PR DESCRIPTION
Remove Laravel as a direct dependency of this package as subpackages can determine what the allowed version could be.